### PR TITLE
Add Strava data exposure incident to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ The best way to learn about opsec is to learn how people fail.
 - Old cat, new tricks, [bad habits](https://www.pwc.com/gx/en/issues/cybersecurity/cyber-threat-intelligence/old-cat-new-tricks.html)
 - Geost botnet discovery of a new Android banking trojan from an [OpSec error](https://www.virusbulletin.com/virusbulletin/2019/10/vb2019-paper-geost-botnet-story-discovery-new-android-banking-trojan-opsec-error/)
 - Opsec Mistakes Reveal [COBALT MIRAGE Threat Actors](https://www.secureworks.com/blog/opsec-mistakes-reveal-cobalt-mirage-threat-actors)
+- Strava data shared by bodyguards exposed [Swedish PM’s private address](https://www.theguardian.com/world/2025/jul/08/swedish-pm-safety-strava-data-bodyguards-ulf-kristersson-running-cycling-routes)


### PR DESCRIPTION
The Dagens Nyheter newspaper tracked more than 1,400 training activities carried out by seven bodyguards who have protected people in government positions over the past year. Their findings covered locations across the world – including close to the Ukrainian border in Poland, the seafront in Tel Aviv, ski slopes in the Alps, Central Park in New York, military bases in Mali and an island in the Seychelles.